### PR TITLE
Removed rail from dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "jaxlib",
     "interpax",
     "jax_cosmo",
-    "rail",
     "pz-rail-dsps"
 ]
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Problem : crash at init
Solution : Removed rail from dependencies. RAIL must be installed separately as per [instructions](https://rail-hub.readthedocs.io/en/latest/source/installation.html#production-installation).

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
