### PR TITLE
Robustify the use of jax.*.trapezoid after it failed to load at IDRIS

### DIFF
--- a/src/rail/dsps_fors2_pz/cosmology.py
+++ b/src/rail/dsps_fors2_pz/cosmology.py
@@ -7,6 +7,14 @@ import jax_cosmo as jc
 from jax import jit
 from jax import numpy as jnp
 
+try:
+    from jax.numpy import trapezoid
+except ImportError:
+    try:
+        from jax.scipy.integrate import trapezoid
+    except ImportError:
+        from jax.numpy import trapz as trapezoid
+
 # pi
 # pi = 3.14159265359 #on utilise np.pi
 # c
@@ -198,7 +206,7 @@ def distMet(cosmo, z):
         dz = z / 50.0
         zi = jnp.linspace(0.5 * dz, z, num=50)
         Ez = jnp.power((cosmo.om0 * jnp.power((1.0 + zi), 3.0) + (1 - cosmo.om0 - cosmo.l0) * jnp.power((1.0 + zi), 2.0) + cosmo.l0), -0.5)
-        _sum = jnp.trapz(Ez, zi)
+        _sum = trapezoid(Ez, zi)
         # for i in range(50):
         #    zi = (i+0.5)*dz
         #    Ez = jnp.sqrt(cosmo.om0*jnp.power((1.+zi),3.)+(1-cosmo.om0-cosmo.l0)*jnp.power((1.+zi),2.)+cosmo.l0)

--- a/src/rail/dsps_fors2_pz/filter.py
+++ b/src/rail/dsps_fors2_pz/filter.py
@@ -9,6 +9,14 @@ import jax.numpy as jnp
 import numpy as np
 from jax import jit
 
+try:
+    from jax.numpy import trapezoid
+except ImportError:
+    try:
+        from jax.scipy.integrate import trapezoid
+    except ImportError:
+        from jax.numpy import trapz as trapezoid
+
 lightspeed = 2.998e18  # AA/s
 ab_gnu = 3.631e-20  # AB reference spctrum in erg/s/cm^2/Hz
 
@@ -53,7 +61,7 @@ def lambda_mean(wls, trans):
     :return: the mean wavelength of the filter wrt transmission values
     :rtype: float
     """
-    mean_wl = jnp.trapezoid(wls * trans, wls) / jnp.trapezoid(trans, wls)
+    mean_wl = trapezoid(wls * trans, wls) / trapezoid(trans, wls)
     return mean_wl
 
 
@@ -145,10 +153,10 @@ def noJit_get_properties(filtwave, filttransm):
     of many of these quantities.
     """
     # Calculate some useful integrals
-    i0 = jnp.trapezoid(filttransm * jnp.log(filtwave), x=jnp.log(filtwave))
-    i1 = jnp.trapezoid(filttransm, x=jnp.log(filtwave))
-    i2 = jnp.trapezoid(filttransm * filtwave, x=filtwave)
-    i3 = jnp.trapezoid(filttransm, x=filtwave)
+    i0 = trapezoid(filttransm * jnp.log(filtwave), x=jnp.log(filtwave))
+    i1 = trapezoid(filttransm, x=jnp.log(filtwave))
+    i2 = trapezoid(filttransm * filtwave, x=filtwave)
+    i3 = trapezoid(filttransm, x=filtwave)
 
     wave_effective = jnp.exp(i0 / i1)
     wave_pivot = jnp.sqrt(i2 / i1)  # noqa: F841
@@ -156,7 +164,7 @@ def noJit_get_properties(filtwave, filttransm):
     wave_average = i2 / i3  # noqa: F841
     rectangular_width = i3 / jnp.max(filttransm)  # noqa: F841
 
-    i4 = jnp.trapezoid(filttransm * jnp.power((jnp.log(filtwave / wave_effective)), 2.0), x=jnp.log(filtwave))
+    i4 = trapezoid(filttransm * jnp.power((jnp.log(filtwave / wave_effective)), 2.0), x=jnp.log(filtwave))
     gauss_width = jnp.power((i4 / i1), 0.5)
     effective_width = 2.0 * jnp.sqrt(2.0 * jnp.log(2.0)) * gauss_width * wave_effective  # noqa: F841
 
@@ -178,10 +186,10 @@ def get_properties(filtwave, filttransm):
     of many of these quantities.
     """
     # Calculate some useful integrals
-    i0 = jnp.trapezoid(filttransm * jnp.log(filtwave), x=jnp.log(filtwave))
-    i1 = jnp.trapezoid(filttransm, x=jnp.log(filtwave))
-    i2 = jnp.trapezoid(filttransm * filtwave, x=filtwave)
-    i3 = jnp.trapezoid(filttransm, x=filtwave)
+    i0 = trapezoid(filttransm * jnp.log(filtwave), x=jnp.log(filtwave))
+    i1 = trapezoid(filttransm, x=jnp.log(filtwave))
+    i2 = trapezoid(filttransm * filtwave, x=filtwave)
+    i3 = trapezoid(filttransm, x=filtwave)
 
     wave_effective = jnp.exp(i0 / i1)
     wave_pivot = jnp.sqrt(i2 / i1)  # noqa: F841
@@ -189,7 +197,7 @@ def get_properties(filtwave, filttransm):
     wave_average = i2 / i3  # noqa: F841
     rectangular_width = i3 / jnp.max(filttransm)  # noqa: F841
 
-    i4 = jnp.trapezoid(filttransm * jnp.power((jnp.log(filtwave / wave_effective)), 2.0), x=jnp.log(filtwave))
+    i4 = trapezoid(filttransm * jnp.power((jnp.log(filtwave / wave_effective)), 2.0), x=jnp.log(filtwave))
     gauss_width = jnp.power((i4 / i1), 0.5)
     effective_width = 2.0 * jnp.sqrt(2.0 * jnp.log(2.0)) * gauss_width * wave_effective  # noqa: F841
 
@@ -244,7 +252,7 @@ def noJit_obj_counts_hires(filtwave, filt_trans, sourcewave, sourceflux):
     newtrans = jnp.interp(sourcewave, filtwave, filt_trans, left=0.0, right=0.0, period=None)
 
     # Integrate lambda*f_lambda*R
-    counts = jnp.trapezoid(sourcewave * newtrans * sourceflux, x=sourcewave)
+    counts = trapezoid(sourcewave * newtrans * sourceflux, x=sourcewave)
     return counts
 
 
@@ -269,7 +277,7 @@ def obj_counts_hires(filtwave, filt_trans, sourcewave, sourceflux):
     newtrans = jnp.interp(sourcewave, filtwave, filt_trans, left=0.0, right=0.0, period=None)
 
     # Integrate lambda*f_lambda*R
-    counts = jnp.trapezoid(sourcewave * newtrans * sourceflux, x=sourcewave)
+    counts = trapezoid(sourcewave * newtrans * sourceflux, x=sourcewave)
     return counts
 
 

--- a/src/rail/dsps_fors2_pz/template.py
+++ b/src/rail/dsps_fors2_pz/template.py
@@ -22,7 +22,13 @@ from diffstar.defaults import DiffstarUParams  # , DEFAULT_Q_PARAMS
 from rail.dsps import calc_obs_mag, calc_rest_mag, DEFAULT_COSMOLOGY, age_at_z
 from dsps.dust.att_curves import _frac_transmission_from_k_lambda, sbl18_k_lambda
 from interpax import interp1d
-from jax.numpy import trapezoid as trapz
+try:
+    from jax.numpy import trapezoid
+except ImportError:
+    try:
+        from jax.scipy.integrate import trapezoid
+    except ImportError:
+        from jax.numpy import trapz as trapezoid
 from astropy import constants as const
 
 from .met_weights_age_dep import calc_rest_sed_sfh_table_lognormal_mdf_agedep
@@ -253,7 +259,7 @@ def calc_eqw(sur_wls, sur_spec, lin):
     nancont = jnp.where((sur_wls > lin - cont_wid) * (sur_wls < lin - line_wid) + (sur_wls > lin + line_wid) * (sur_wls < lin + cont_wid), sur_spec, jnp.nan)
     height = jnp.nanmean(nancont)
     vals = jnp.where((sur_wls > lin - line_wid) * (sur_wls < lin + line_wid), sur_spec / height - 1.0, 0.0)
-    ew = trapz(vals, x=sur_wls)
+    ew = trapezoid(vals, x=sur_wls)
     return ew
 
 


### PR DESCRIPTION
## Problem & Solution Description (including issue #)
Problem : encountered failures at loading jax.numpy.trapezoid at IDRIS (jax 0.4.24)
Solution : Try imports from `jax.numpy` or `jax.scipy.integrate` depending on whether an exception `ImportError` is thrown.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
