### PR TITLE
Thorough refresh to make a better use of JAX and GPUs and to allow no…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "jaxlib",
     "interpax",
     "jax_cosmo",
+    "pandas",
     "pz-rail-dsps"
 ]
 

--- a/src/rail/dsps_fors2_pz/__init__.py
+++ b/src/rail/dsps_fors2_pz/__init__.py
@@ -8,6 +8,8 @@ from .galaxy import (
     likelihood,
     likelihood_fluxRatio,
     load_galaxy,
+    load_magnitudes,
+    mags_to_i_and_colors,
     neg_log_likelihood,
     neg_log_posterior,
     posterior,
@@ -15,6 +17,8 @@ from .galaxy import (
     val_neg_log_likelihood,
     val_neg_log_posterior,
     vmap_chi_term,
+    vmap_load_magnitudes,
+    vmap_mags_to_i_and_colors,
     vmap_neg_log_likelihood,
     vmap_neg_log_posterior,
     vmap_nz_prior,
@@ -23,7 +27,23 @@ from .galaxy import (
 from .template import BaseTemplate, SPS_Templates, make_legacy_templates, make_sps_templates, templ_mags, templ_mags_legacy, v_mags, v_mags_legacy
 from .met_weights_age_dep import calc_rest_sed_sfh_table_lognormal_mdf_agedep
 from .dsps_params import SSPParametersFit, paramslist_to_dict
-from .io_utils import PZDATALOC, DEFAULTS_DICT, json_to_inputs, load_ssp, templatesToHDF5, readTemplatesHDF5, photoZtoHDF5, readPhotoZHDF5, readDSPSHDF5, has_redshift, load_data_for_run
+from .io_utils import (
+    PZDATALOC,
+    DEFAULTS_DICT,
+    json_to_inputs,
+    load_ssp,
+    templatesToHDF5,
+    readTemplatesHDF5,
+    photoZtoHDF5,
+    readPhotoZHDF5,
+    readDSPSHDF5,
+    has_redshift,
+    load_data_for_run,
+    readCatalogHDF5,
+    catalog_ASCIItoHDF5,
+    readPZinputsHDF5,
+    pzInputsToHDF5
+)
 
 __all__ = [
     "PZDATALOC",
@@ -60,11 +80,15 @@ __all__ = [
     "prior_ft",
     "Observation",
     "load_galaxy",
+    "load_magnitudes",
+    "mags_to_i_and_colors",
     "chi_term",
     "col_to_fluxRatio",
     "neg_log_posterior",
     "val_neg_log_posterior",
     "vmap_chi_term",
+    "vmap_load_magnitudes",
+    "vmap_mags_to_i_and_colors",
     "vmap_neg_log_posterior",
     "vmap_nz_prior",
     "z_prior_val",
@@ -82,6 +106,10 @@ __all__ = [
     "photoZtoHDF5",
     "readPhotoZHDF5",
     "readDSPSHDF5",
+    "readCatalogHDF5",
+    "catalog_ASCIItoHDF5",
+    "readPZinputsHDF5",
+    "pzInputsToHDF5",
     "has_redshift",
     "run_from_inputs"
 ]

--- a/src/rail/dsps_fors2_pz/data/PZ_analysis.ipynb
+++ b/src/rail/dsps_fors2_pz/data/PZ_analysis.ipynb
@@ -194,11 +194,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "z_grid = jnp.arange(\n",
-    "    inputs_pz[\"Z_GRID\"][\"z_min\"],\n",
-    "    inputs_pz[\"Z_GRID\"][\"z_max\"] + inputs_pz[\"Z_GRID\"][\"z_step\"],\n",
-    "    inputs_pz[\"Z_GRID\"][\"z_step\"]\n",
-    ")"
+    "z_grid = jnp.arange(inputs_pz[\"Z_GRID\"][\"z_min\"], inputs_pz[\"Z_GRID\"][\"z_max\"] + inputs_pz[\"Z_GRID\"][\"z_step\"], inputs_pz[\"Z_GRID\"][\"z_step\"])\n",
+    "# or equivalently\n",
+    "z_grid = pz_res_tree[\"z_grid\"]"
    ]
   },
   {
@@ -214,14 +212,15 @@
     "%matplotlib inline\n",
     "\n",
     "\n",
-    "def _plot_pdz(obs):\n",
-    "    z, pdz = obs[\"PDZ\"][:, 0], obs[\"PDZ\"][:, 1]\n",
-    "    zs = obs[\"z_spec\"]\n",
-    "    mean = obs[\"z_mean\"]\n",
-    "    medz = obs[\"z_med\"]\n",
+    "def _plot_pdz(pz_res_dict, obsid):\n",
+    "    z = pz_res_dict[\"z_grid\"]\n",
+    "    pdz = pz_res_dict[\"PDZ\"][:, obsid]\n",
+    "    mean = pz_res_dict[\"z_mean\"][obsid]\n",
+    "    zs = pz_res_dict[\"z_spec\"][obsid]\n",
+    "    medz = pz_res_dict[\"z_med\"][obsid]\n",
     "\n",
     "    plt.semilogy(z, pdz)\n",
-    "    if zs is not None:\n",
+    "    if jnp.isfinite(zs):\n",
     "        plt.axvline(zs, c=\"k\", label=\"z_spec\")\n",
     "    plt.axvline(mean, c=\"r\", label=\"Mean\")\n",
     "    plt.axvline(medz, c=\"g\", label=\"Median\")\n",
@@ -236,7 +235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "randomid = np.random.choice(len(pz_res_tree))"
+    "randomid = np.random.choice(pz_res_tree[\"PDZ\"].shape[1])"
    ]
   },
   {
@@ -246,8 +245,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obs0 = pz_res_tree[randomid]\n",
-    "_plot_pdz(obs0)"
+    "_plot_pdz(pz_res_tree, randomid)"
    ]
   },
   {
@@ -257,43 +255,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tqdm import tqdm\n",
-    "\n",
-    "f, a = plt.subplots(1, 1, figsize=(6,6))\n",
-    "zp = []\n",
-    "zs = []\n",
-    "znan = []\n",
-    "for obs in tqdm(pz_res_tree):\n",
-    "    #a[0].plot(z_grid, obs['PDZ'])\n",
-    "    try:\n",
-    "        zp.append(obs['z_ML'])\n",
-    "        zs.append(obs['z_spec'])\n",
-    "    except ValueError:\n",
-    "        znan.append(obs['z_spec'])\n",
-    "    #try:\n",
-    "    #    meanz, medz = stats(z_grid, obs['PDZ'])\n",
-    "    #    zp.append(medz)\n",
-    "    #    zs.append(obs['z_spec'])\n",
-    "    #except IndexError:\n",
-    "    #    pass\n",
+    "f, a = plt.subplots(1, 1, figsize=(6, 6))\n",
+    "zp = pz_res_tree[\"z_ML\"]\n",
+    "zs = pz_res_tree[\"z_spec\"]\n",
     "\n",
     "zp = np.array(zp)\n",
     "zs = np.array(zs)\n",
     "\n",
-    "bias = np.abs(zp-zs)\n",
-    "outliers = np.nonzero(bias > 0.15*(1+zs))\n",
-    "outl_rate = 100. * len(zs[outliers]) / len(zs)\n",
+    "bias = np.abs(zp - zs)\n",
+    "outliers = np.nonzero(bias > 0.15 * (1 + zs))\n",
+    "outl_rate = 100.0 * len(zs[outliers]) / len(zs)\n",
     "\n",
-    "a.scatter(zs, zp, s=4, alpha=0.2, label=f\"SPS: {outl_rate:.3f}% outliers\", color='green')\n",
-    "a.plot(z_grid, z_grid, c='k', ls=':', lw=1)\n",
-    "a.plot(z_grid, z_grid+0.15*(1+z_grid), c='k', lw=2)\n",
-    "a.plot(z_grid, z_grid-0.15*(1+z_grid), c='k', lw=2)\n",
-    "a.set_xlabel('z_spec')\n",
-    "a.set_ylabel('z_phot')\n",
+    "a.scatter(zs, zp, s=4, alpha=0.2, label=f\"SPS: {outl_rate:.3f}% outliers\", color=\"green\")\n",
+    "a.plot(z_grid, z_grid, c=\"k\", ls=\":\", lw=1)\n",
+    "a.plot(z_grid, z_grid + 0.15 * (1 + z_grid), c=\"k\", lw=2)\n",
+    "a.plot(z_grid, z_grid - 0.15 * (1 + z_grid), c=\"k\", lw=2)\n",
+    "a.set_xlabel(\"z_spec\")\n",
+    "a.set_ylabel(\"z_phot\")\n",
     "a.legend()\n",
     "a.grid()\n",
-    "#a.set_xlim(0., 3.1)\n",
-    "#a.set_ylim(0., 3.1)"
+    "# a.set_xlim(0., 3.1)\n",
+    "# a.set_ylim(0., 3.1)"
    ]
   },
   {
@@ -304,6 +286,82 @@
    "outputs": [],
    "source": [
     "print(f\"SPS templates : {outl_rate:.3f}% outliers out of {len(zp)} successful fits.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a8097008",
+   "metadata": {},
+   "source": [
+    "## Some checks\n",
+    "Let's have a look at files that were created along the way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2472ac1c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "\n",
+    "from rail.dsps_fors2_pz import readTemplatesHDF5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcbe3c3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db91f069",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h5cat = \"COSMOS2020_emu_hscOnly_CC_zinf3_noNaN.h5\"\n",
+    "h5inp = \"pz_inputs_COSMOS2020_emu_hscOnly_CC_zinf3_noNaN.h5\"\n",
+    "h5templ = \"SEDtempl_SPS_mags+rews_1_to_10.h5\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23556cf3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_cat = pd.read_hdf(h5cat, key=\"catalog\")\n",
+    "df_cat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c1184089",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_inp = pd.read_hdf(h5inp, key=\"pz_inputs\")\n",
+    "df_inp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb39476d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dict_templ = readTemplatesHDF5(h5templ)\n",
+    "dict_templ"
    ]
   }
  ],

--- a/src/rail/dsps_fors2_pz/data/defaults.json
+++ b/src/rail/dsps_fors2_pz/data/defaults.json
@@ -47,7 +47,9 @@
         "i_band_num": 3,
         "Dataset": {
             "path": "COSMOS2020_emu_hscOnly_CC_zinf3_noNaN.inp",
-            "type": "F"
+            "type": "F",
+            "format": "ASCII",
+            "overwrite": true
         },
         "Estimator": "chi2",
         "prior": true,

--- a/src/rail/dsps_fors2_pz/data/defaults.json
+++ b/src/rail/dsps_fors2_pz/data/defaults.json
@@ -48,7 +48,7 @@
         "Dataset": {
             "path": "COSMOS2020_emu_hscOnly_CC_zinf3_noNaN.inp",
             "type": "F",
-            "format": "ASCII",
+            "is_ascii": true,
             "overwrite": true
         },
         "Estimator": "chi2",

--- a/src/rail/dsps_fors2_pz/data/process_fors2_cosmos2020_allFilts.json
+++ b/src/rail/dsps_fors2_pz/data/process_fors2_cosmos2020_allFilts.json
@@ -166,7 +166,7 @@
         "Dataset": {
             "path": "COSMOS2020_emu_CC.inp",
             "type": "F",
-            "format": "ASCII",
+            "is_ascii": true,
             "overwrite": true
         },
         "Estimator": "chi2",

--- a/src/rail/dsps_fors2_pz/data/process_fors2_cosmos2020_allFilts.json
+++ b/src/rail/dsps_fors2_pz/data/process_fors2_cosmos2020_allFilts.json
@@ -165,10 +165,12 @@
         "i_band_num": 4,
         "Dataset": {
             "path": "COSMOS2020_emu_CC.inp",
-            "type": "F"
+            "type": "F",
+            "format": "ASCII",
+            "overwrite": true
         },
         "Estimator": "chi2",
-        "prior": true,
+        "prior": false,
         "use_colors": true,
         "save results": true,
         "run name": "process_fors2_pz_COSMOS2020"

--- a/src/rail/dsps_fors2_pz/galaxy.py
+++ b/src/rail/dsps_fors2_pz/galaxy.py
@@ -31,14 +31,82 @@ def load_galaxy(photometry, ismag, id_i_band=3):
         c_ab = _phot[:-1] - _phot[1:]
         c_ab_err = jnp.power(jnp.power(_phot_errs[:-1], 2) + jnp.power(_phot_errs[1:], 2), 0.5)
         i_ab = _phot[id_i_band]
-        filters_to_use = _phot > 0.0
+        filters_to_use = jnp.logical_and(_phot > -15.0, _phot < 50.0)
     else:
         c_ab = -2.5 * jnp.log10(_phot[:-1] / _phot[1:])
         c_ab_err = 2.5 / jnp.log(10) * jnp.power(jnp.power(_phot_errs[:-1] / _phot[:-1], 2) + jnp.power(_phot_errs[1:] / _phot[1:], 2), 0.5)
         i_ab = -2.5 * jnp.log10(_phot[id_i_band]) - 48.6
-        filters_to_use = jnp.isfinite(_phot)
+        filters_to_use = jnp.logical_and(_phot > 0.0, _phot_errs > 0.0)
     colors_to_use = jnp.array([b1 and b2 for (b1, b2) in zip(filters_to_use[:-1], filters_to_use[1:], strict=True)])
     return i_ab, c_ab, c_ab_err, filters_to_use, colors_to_use
+
+
+def load_magnitudes(photometry, ismag):
+    """load_magnitudes Returns the magnitudes and associated errors from photometric data that can be either fluxes or magnitudes.
+    Contrary to `load_galaxy`, this function does not compute color indices, identifies i-mag or returns the booleans.
+    Instead, it returns the data as JAX arrays with `nan` wherever data is missing.
+    This is more a helper to build on, especially aimed at converting ASCII data to a `DataFrame` or `HDF5` file,
+    and cannot be used directly to built an `Observation` object.
+
+    :param photometry: fluxes or magnitudes and corresponding errors as read from an ASCII input file
+    :type photometry: list or array-like
+    :param ismag: whether photometry is provided as AB-magnitudes or fluxes
+    :type ismag: bool
+    :return: Tuple containing the AB magnitudes (in AB mag units) and the corresponding errors.
+    :rtype: tuple
+    """
+    assert len(photometry) % 2 == 0, "Missing data in observations : check that magnitudes/fluxes and errors are available\n and listed as M (or F), error, M (or F), error, etc."
+
+    if ismag:
+        _phot_ab = jnp.array([photometry[2 * i] for i in range(len(photometry) // 2)])
+        _phot_ab_errs = jnp.array([photometry[2 * i + 1] for i in range(len(photometry) // 2)])
+        filters_to_use = jnp.logical_and(_phot_ab > -15.0, _phot_ab_errs < 50.0)
+    else:
+        _phot = jnp.array([photometry[2 * i] for i in range(len(photometry) // 2)])
+        _phot_errs = jnp.array([photometry[2 * i + 1] for i in range(len(photometry) // 2)])
+        _phot_ab = -2.5 * jnp.log10(_phot) - 48.6
+        _phot_ab_errs = (2.5 / jnp.log(10)) * (_phot_errs / _phot)
+        filters_to_use = jnp.logical_and(_phot > 0.0, _phot_errs > 0.0)
+
+    mag_ab = jnp.where(filters_to_use, _phot_ab, jnp.nan)
+    mag_ab_err = jnp.where(filters_to_use, _phot_ab_errs, jnp.nan)
+
+    return mag_ab, mag_ab_err
+
+
+vmap_load_magnitudes = vmap(load_magnitudes, in_axes=(0, None))
+
+
+def mags_to_i_and_colors(mags_arr, mags_err_arr, id_i_band):
+    """mags_to_i_and_colors Extracts magnitude in i-band and computes color indices and associated errors for photo-z estimation for a single observed galaxy (input).
+
+    :param mags_arr: AB-magnitudes of the galaxy from the input catalog
+    :type mags_arr: jax.array
+    :param mags_err_arr: Errors in AB-magnitudes of the galaxy from the input catalog
+    :type mags_err_arr: jax.array
+    :param id_i_band: Identifier of the i-band in the input catalog's photometric system. Starts from 0, such as `i_mag = mags_arr[id_i_band]`.
+    :type id_i_band: int
+    :return: 3-tuple of JAX arrays containing processed input data : (i_mag ; color indices ; errors on color indices)
+    :rtype: tuple of jax.array
+    """
+    c_ab = mags_arr[:-1] - mags_arr[1:]
+    c_ab_err = jnp.power(jnp.power(mags_err_arr[:-1], 2) + jnp.power(mags_err_arr[1:], 2), 0.5)
+    i_ab = mags_arr[id_i_band]
+
+    filters_to_use = jnp.logical_and(jnp.isfinite(mags_arr), jnp.isfinite(mags_err_arr))
+
+    colors_to_use = jnp.array(tuple(jnp.logical_and(filters_to_use[i], filters_to_use[i + 1]) for i in range(len(filters_to_use) - 1)))
+
+    ab_colors = jnp.where(colors_to_use, c_ab, jnp.nan)
+    ab_cols_errs = jnp.where(colors_to_use, c_ab_err, jnp.nan)
+
+    use_i = filters_to_use[id_i_band]
+    i_mag_ab = jnp.where(use_i, i_ab, jnp.nan)
+
+    return i_mag_ab, ab_colors, ab_cols_errs
+
+
+vmap_mags_to_i_and_colors = vmap(mags_to_i_and_colors, in_axes=(0, 0, None))
 
 
 @jit
@@ -98,7 +166,10 @@ def z_prior_val(i_mag, zp, nuvk):
     return val_prior
 
 
-vmap_nz_prior = vmap(z_prior_val, in_axes=(None, 0, 0))  # vmap version to compute the prior value for a certain observation and a certain SED template at all redshifts
+vmap_nz_prior = vmap(
+    vmap(z_prior_val, in_axes=(0, None, None)),  # vmap version to compute the prior value for a certain observation and a certain SED template at all redshifts
+    in_axes=(None, 0, 0),
+)
 
 
 @jit
@@ -122,32 +193,41 @@ def val_neg_log_posterior(z_val, templ_cols, gal_cols, gel_colerrs, gal_iab, tem
     :rtype: float
     """
     _chi = chi_term(gal_cols, templ_cols, gel_colerrs)
+    chi = jnp.where(jnp.isfinite(_chi), _chi, 0.0)
+    _count = jnp.sum(jnp.where(jnp.isfinite(_chi), 1.0, 0.0))
     _prior = z_prior_val(gal_iab, z_val, templ_nuvk)
-    return jnp.sum(_chi) / len(_chi) - 2 * jnp.log(_prior)
+    return jnp.sum(chi) / _count - 2 * jnp.log(_prior)
 
 
-vmap_neg_log_posterior = vmap(val_neg_log_posterior, in_axes=(0, 0, None, None, None, 0))
+vmap_neg_log_posterior = vmap(
+    vmap(
+        val_neg_log_posterior,
+        in_axes=(None, None, 0, 0, 0, None),  # Same as above but for all observations...
+    ),
+    in_axes=(0, 0, None, None, None, 0),  # ... and for all redshifts
+)
 
 
-# @jit
-def neg_log_posterior(sps_temp, obs_gal):
-    r"""neg_log_posterior Computes the posterior distribution of redshifts (negative log posterior, similar to a $\chi^2$) for a combination of template x observation.
+@jit
+def neg_log_posterior(sps_temp, obs_ab_colors, obs_ab_colerrs, obs_iab, z_grid, nuvk):
+    r"""neg_log_posterior Computes the posterior distribution of redshifts (negative log posterior, similar to a $\chi^2$) with one template for all observations.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
     :return: negative log posterior values along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    neglog_post = vmap_neg_log_posterior(sps_temp.z_grid, sps_temp.colors[:, _sel], obs_gal.AB_colors[_sel], obs_gal.AB_colerrs[_sel], obs_gal.ref_i_AB, sps_temp.nuvk)
+    neglog_post = vmap_neg_log_posterior(z_grid, sps_temp, obs_ab_colors, obs_ab_colerrs, obs_iab, nuvk)
     return neglog_post
 
 
 @jit
 def val_neg_log_likelihood(templ_cols, gal_cols, gel_colerrs):
-    r"""val_neg_log_likelihood Computes the negative log likelihood of the redshift for an observation, given a template galaxy.
+    r"""val_neg_log_likelihood Computes the negative log likelihood of the redshift with one template for all observations.
     This is a reduced $\chi^2$ and does not use a prior probability distribution.
 
     :param templ_cols: Color indices of the galaxy template
@@ -156,104 +236,111 @@ def val_neg_log_likelihood(templ_cols, gal_cols, gel_colerrs):
     :type gal_cols: array of floats
     :param gel_colerrs: Color errors/dispersion/noise of the observed object
     :type gel_colerrs: array of floats
-    :return: Likelihood of the redshift zp for this observation, if represented by the given template.
+    :return: Likelihood of the redshift zp, if represented by the given template.
     :rtype: float
     """
     _chi = chi_term(gal_cols, templ_cols, gel_colerrs)
-    return jnp.sum(_chi) / len(_chi)
+    chi = jnp.where(jnp.isfinite(_chi), _chi, 0.0)
+    _count = jnp.sum(jnp.where(jnp.isfinite(_chi), 1.0, 0.0))
+    return jnp.sum(chi) / _count
 
 
-vmap_neg_log_likelihood = vmap(val_neg_log_likelihood, in_axes=(0, None, None))  # Same as above but for all templates.
+vmap_neg_log_likelihood = vmap(
+    vmap(val_neg_log_likelihood, in_axes=(None, 0, 0)),  # Same as above but for all observations...
+    in_axes=(0, None, None),  # ... and for all redshifts
+)
 
 
-# @jit
-def neg_log_likelihood(sps_temp, obs_gal):
-    r"""neg_log_likelihood Computes the negative log likelihood of redshifts (aka $\chi^2$) for a combination of template x observation.
+@jit
+def neg_log_likelihood(sps_temp, obs_ab_colors, obs_ab_colerrs):
+    r"""neg_log_likelihood Computes the negative log likelihood of redshifts (aka $\chi^2$) with one template for all observations.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
-    :return: negative log likelihood values (aka $\chi^2$) along the redshift grid
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
+    :return: likelihood values (*i.e.* $\exp \left( - \frac{\chi^2}{2} \right)$) along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    neglog_lik = vmap_neg_log_likelihood(sps_temp.colors[:, _sel], obs_gal.AB_colors[_sel], obs_gal.AB_colerrs[_sel])
+    neglog_lik = vmap_neg_log_likelihood(sps_temp, obs_ab_colors, obs_ab_colerrs)
     return neglog_lik
 
 
-def likelihood(sps_temp, obs_gal):
-    r"""likelihood Computes the likelihood of redshifts for a combination of template x observation.
+@jit
+def likelihood(sps_temp, obs_ab_colors, obs_ab_colerrs):
+    r"""likelihood Computes the likelihood of redshifts with one template for all observations.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
     :return: likelihood values (*i.e.* $\exp \left( - \frac{\chi^2}{2} \right)$) along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    neglog_lik = vmap_neg_log_likelihood(sps_temp.colors[:, _sel], obs_gal.AB_colors[_sel], obs_gal.AB_colerrs[_sel])
+    neglog_lik = vmap_neg_log_likelihood(sps_temp, obs_ab_colors, obs_ab_colerrs)
     return jnp.exp(-0.5 * neglog_lik)
 
 
-def likelihood_fluxRatio(sps_temp, obs_gal):
-    r"""likelihood Computes the likelihood of redshifts for a combination of template x observation.
+def likelihood_fluxRatio(sps_temp, obs_ab_colors, obs_ab_colerrs):
+    r"""likelihood_fluxRatio Computes the likelihood of redshifts with one template for all observations.
     Uses the $\chi^2$ distribution in flux-ratio space instead of color space.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
     :return: likelihood values (*i.e.* $\exp \left( - \frac{\chi^2}{2} \right)$) along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    obs, ref, err = col_to_fluxRatio(obs_gal.AB_colors[_sel], sps_temp.colors[:, _sel], obs_gal.AB_colerrs[_sel])
+    obs, ref, err = col_to_fluxRatio(obs_ab_colors, sps_temp, obs_ab_colerrs)
     neglog_lik = vmap_neg_log_likelihood(ref, obs, err)
     return jnp.exp(-0.5 * neglog_lik)
 
 
 # @jit
-def posterior(sps_temp, obs_gal):
-    r"""posterior Computes the posterior distribution of redshifts for a combination of template x observation.
+def posterior(sps_temp, obs_ab_colors, obs_ab_colerrs, obs_iab, z_grid, nuvk):
+    r"""posterior Computes the posterior distribution of redshifts with one template for all observations.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
     :return: posterior probability values (*i.e.* $\exp \left( - \frac{\chi^2}{2} \right) \times prior$) along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    chi2_arr = vmap_neg_log_likelihood(sps_temp.colors[:, _sel], obs_gal.AB_colors[_sel], obs_gal.AB_colerrs[_sel])
-    # neglog_lik = chi2_arr - 500.
-    _n1 = 10.0 / jnp.max(chi2_arr)
+    chi2_arr = vmap_neg_log_likelihood(sps_temp, obs_ab_colors, obs_ab_colerrs)
+    _n1 = 100.0 / jnp.nanmax(chi2_arr)
     neglog_lik = _n1 * chi2_arr
-    prior_val = vmap_nz_prior(obs_gal.ref_i_AB, sps_temp.z_grid, sps_temp.nuvk)
-    # res = jnp.exp(-0.5 * neglog_lik) * prior_val
+    prior_val = vmap_nz_prior(obs_iab, z_grid, nuvk)
     res = jnp.power(jnp.exp(-0.5 * neglog_lik), 1 / _n1) * prior_val
     return res
 
 
-def posterior_fluxRatio(sps_temp, obs_gal):
-    r"""posterior Computes the posterior distribution of redshifts for a combination of template x observation.
+def posterior_fluxRatio(sps_temp, obs_ab_colors, obs_ab_colerrs, obs_iab, z_grid, nuvk):
+    r"""posterior_fluxRatio Computes the posterior distribution of redshifts with one template for all observations.
     Uses the $\chi^2$ distribution in flux-ratio space instead of color space.
 
-    :param sps_temp: SPS template to be used as reference
-    :type sps_temp: SPS_template object (namedtuple)
-    :param obs_gal: Observed galaxy
-    :type obs_gal: Observation object (namedtuple)
+    :param sps_temp: Colors of SPS template to be used as reference
+    :type sps_temp: array of shape (n_redshift, n_colors)
+    :param obs_ab_colors: Observed colors for all galaxies
+    :type obs_ab_colors: array of shape (n_galaxies, n_colors)
+    :param obs_ab_colerrs: Observed noise of colors for all galaxies
+    :type obs_ab_colerrs: array of shape (n_galaxies, n_colors)
     :return: posterior probability values (*i.e.* $\exp \left( - \frac{\chi^2}{2} \right) \times prior$) along the redshift grid
     :rtype: jax array
     """
-    _sel = obs_gal.valid_colors
-    obs, ref, err = col_to_fluxRatio(obs_gal.AB_colors[_sel], sps_temp.colors[:, _sel], obs_gal.AB_colerrs[_sel])
+    obs, ref, err = col_to_fluxRatio(obs_ab_colors, sps_temp, obs_ab_colerrs)
     chi2_arr = vmap_neg_log_likelihood(ref, obs, err)
-    # neglog_lik = chi2_arr - 500.
-    _n1 = 10.0 / jnp.max(chi2_arr)
+    _n1 = 100.0 / jnp.nanmax(chi2_arr)
     neglog_lik = _n1 * chi2_arr
-    prior_val = vmap_nz_prior(obs_gal.ref_i_AB, sps_temp.z_grid, sps_temp.nuvk)
-    # res = jnp.exp(-0.5 * neglog_lik) * prior_val
+    prior_val = vmap_nz_prior(obs_iab, z_grid, nuvk)
     res = jnp.power(jnp.exp(-0.5 * neglog_lik), 1 / _n1) * prior_val
     return res

--- a/src/rail/dsps_fors2_pz/io_utils.py
+++ b/src/rail/dsps_fors2_pz/io_utils.py
@@ -254,7 +254,7 @@ def load_data_for_run(inp_glob):
     data_path = os.path.abspath(os.path.join(PZDATALOC, inputs["Dataset"]["path"]))
     data_ismag = inputs["Dataset"]["type"].lower() == "m"
 
-    if inputs["Dataset"]["format"].lower() == "ascii":
+    if inputs["Dataset"]["is_ascii"]:
         h5catpath = catalog_ASCIItoHDF5(data_path, data_ismag, filt_names=filters_names)
     else:
         h5catpath = data_path

--- a/src/rail/dsps_fors2_pz/io_utils.py
+++ b/src/rail/dsps_fors2_pz/io_utils.py
@@ -12,6 +12,7 @@ import h5py
 import json
 import jax
 import numpy as np
+import pandas as pd
 from tqdm import tqdm
 from rail.dsps import load_ssp_templates
 from jax import numpy as jnp
@@ -128,54 +129,39 @@ def readTemplatesHDF5(h5file):
     return out_dict
 
 
-def photoZtoHDF5(outfilename, pz_list):
-    """photoZtoHDF5 Saves the pytree of photo-z results (list of dicts) in an HDF5 file.
+def photoZtoHDF5(outfilename, pz_out_dict):
+    """photoZtoHDF5 Saves the dictionary of `process_fors2.photoZ` outputs to an `HDF5` file.
 
     :param outfilename: Name of the `HDF5` file that will be written.
     :type outfilename: str or path-like object
-    :param pz_list: List of dictionaries containing the photo-z results.
-    :type pz_list: list
+    :param pz_out_dict: Dictionary of photo-z results : each item corresponds to the array of values of one result (identified by the key) for all input galaxies.
+    :type pz_out_dict: dict
     :return: Absolute path to the written file - if successful.
     :rtype: str or path-like object
     """
     fileout = os.path.abspath(outfilename)
 
     with h5py.File(fileout, "w") as h5out:
-        for i, posts_dic in enumerate(pz_list):
-            groupout = h5out.create_group(f"{i}")
-            groupout.create_dataset("PDZ", data=posts_dic.pop("PDZ"), compression="gzip", compression_opts=9)
-            groupout.attrs["z_spec"] = posts_dic.pop("z_spec")
-            groupout.attrs["z_ML"] = posts_dic.pop("z_ML")
-            groupout.attrs["z_mean"] = posts_dic.pop("z_mean")
-            groupout.attrs["z_med"] = posts_dic.pop("z_med")
-            for templ, tdic in posts_dic.items():
-                grp_sed = groupout.create_group(templ)
-                grp_sed.attrs["evidence_SED"] = tdic["evidence_SED"]
-                grp_sed.attrs["z_ML_SED"] = tdic["z_ML_SED"]
-                grp_sed.attrs["z_mean_SED"] = tdic["z_mean_SED"]
+        groupout = h5out.create_group("pz_outputs")
+        for key, jarray in pz_out_dict.items():
+            groupout.create_dataset(key, data=jarray, compression="gzip", compression_opts=9)
 
     ret = fileout if os.path.isfile(fileout) else f"Unable to write data to {outfilename}"
     return ret
 
 
 def readPhotoZHDF5(h5file):
-    """readPhotoZHDF5 Reads the photo-z results file and generates the corresponding pytree (list of dictionaries) for analysis.
+    """readPhotoZHDF5 Reads the photo-z results file and generates the corresponding pytree (dictionary) for analysis.
 
     :param h5file: Path to the HDF5 containing the photo-z results.
     :type h5file: str or path-like object
-    :return: List of photo-z results dicts as computed by process_fors2.photoZ.
-    :rtype: list
+    :return: Dictionary of photo-z results as computed by `process_fors2.photoZ`.
+    :rtype: dict
     """
     filein = os.path.abspath(h5file)
-    out_list = []
     with h5py.File(filein, "r") as h5in:
-        for key, grp in h5in.items():
-            obs_dict = {"PDZ": jnp.array(grp.get("PDZ")), "z_spec": grp.attrs.get("z_spec"), "z_ML": grp.attrs.get("z_ML"), "z_mean": grp.attrs.get("z_mean"), "z_med": grp.attrs.get("z_med")}
-            for templ, grp_sed in grp.items():
-                if "SPEC" in templ:
-                    obs_dict.update({templ: dict(grp_sed.attrs.items())})
-            out_list.append(obs_dict)
-    return out_list
+        pzout_dict = {key: jnp.array(jarray) for key, jarray in h5in.get("pz_outputs").items()}
+    return pzout_dict
 
 
 def readDSPSHDF5(h5file):
@@ -225,10 +211,10 @@ def load_data_for_run(inp_glob):
 
     :param inp_glob: input configuration and settings
     :type inp_glob: dict
-    :return: data for photo-z evaluation : redshift grid, templates dictionary and the list of observations
-    :rtype: tuple of jax.ndarray, dictionary, list
+    :return: data for photo-z evaluation : redshift grid, templates dictionary and the arrays of processed observed data (input catalog) (i mags ; colors ; errors on colors ; spectro-z).
+    :rtype: 6-tuple of jax.ndarray, dictionary, jax.ndarray, jax.ndarray, jax.ndarray, jax.ndarray
     """
-    from rail.dsps_fors2_pz import NIR_filt, NUV_filt, Observation, get_2lists, load_filt, load_galaxy, make_legacy_templates, make_sps_templates, sedpyFilter
+    from rail.dsps_fors2_pz import NIR_filt, NUV_filt, get_2lists, load_filt, make_legacy_templates, make_sps_templates, sedpyFilter
 
     _ssp_file = (
         None
@@ -245,7 +231,8 @@ def load_data_for_run(inp_glob):
         filters_dict[_f]["path"] = os.path.abspath(os.path.join(PZDATALOC, filters_dict[_f]["path"]))
     print("Loading filters :")
     filters_arr = tuple(sedpyFilter(*load_filt(int(ident), filters_dict[ident]["path"], filters_dict[ident]["transmission"])) for ident in tqdm(filters_dict)) + (NUV_filt, NIR_filt)
-    N_FILT = len(filters_arr) - 2
+
+    filters_names = [_f["name"] for _, _f in filters_dict.items()]
     # print(f"DEBUG: filters = {filters_arr}")
 
     print("Building templates :")
@@ -253,8 +240,7 @@ def load_data_for_run(inp_glob):
     # sps_temp_pkl = os.path.abspath(inputs["Templates"])
     # sps_par_dict = read_params(sps_temp_pkl)
     if inputs["Templates"]["overwrite"] or not os.path.isfile(os.path.abspath(inputs["Templates"]["output"])):
-        print("Creating new templates - please be patient, this may take several minutes to complete :")
-        sps_temp_h5 = os.path.abspath(os.path.join(PZDATALOC, inputs["Templates"]["input"]))
+        sps_temp_h5 = os.path.abspath(inputs["Templates"]["input"])
         sps_par_dict = readDSPSHDF5(sps_temp_h5)
         if "sps" in inputs["Mode"].lower():
             templ_dict = jax.tree_util.tree_map(lambda dico: make_sps_templates(dico, Xfilt, z_grid, ssp_data, id_imag=inputs["i_band_num"]), sps_par_dict, is_leaf=has_redshift)
@@ -262,29 +248,157 @@ def load_data_for_run(inp_glob):
             templ_dict = jax.tree_util.tree_map(lambda dico: make_legacy_templates(dico, Xfilt, z_grid, ssp_data, id_imag=inputs["i_band_num"]), sps_par_dict, is_leaf=has_redshift)
         _ = templatesToHDF5(inputs["Templates"]["output"], templ_dict)
     else:
-        print("Existing templates found ! Let us use those and save some time.")
         templ_dict = readTemplatesHDF5(inputs["Templates"]["output"])
 
     print("Loading observations :")
     data_path = os.path.abspath(os.path.join(PZDATALOC, inputs["Dataset"]["path"]))
     data_ismag = inputs["Dataset"]["type"].lower() == "m"
 
-    data_file_arr = np.loadtxt(data_path)
-    obs_arr = []
+    if inputs["Dataset"]["format"].lower() == "ascii":
+        h5catpath = catalog_ASCIItoHDF5(data_path, data_ismag, filt_names=filters_names)
+    else:
+        h5catpath = data_path
 
-    for i in tqdm(range(data_file_arr.shape[0])):
-        try:
-            assert (len(data_file_arr[i, :]) == 1 + 2 * N_FILT) or (
-                len(data_file_arr[i, :]) == 1 + 2 * N_FILT + 1
-            ), f"At least one filter is missing in datapoint {data_file_arr[i,0]} : length is {len(data_file_arr[i,:])}, {1+2*N_FILT} values expected.\nDatapoint removed from dataset."
-            # print(int(data_file_arr[i, 0]))
-            if len(data_file_arr[i, :]) == 1 + 2 * N_FILT + 1:
-                observ = Observation(int(data_file_arr[i, 0]), *load_galaxy(data_file_arr[i, 1 : 2 * N_FILT + 1], data_ismag, id_i_band=inputs["i_band_num"]), data_file_arr[i, 2 * N_FILT + 1])
-            else:
-                observ = Observation(int(data_file_arr[i, 0]), *load_galaxy(data_file_arr[i, 1 : 2 * N_FILT + 1], data_ismag, id_i_band=inputs["i_band_num"]), jnp.nan)
-            # print(observ.num)
-            obs_arr.extend([observ])
-        except AssertionError:
-            pass
-    print("All data loaded and ready for use !")
-    return z_grid, templ_dict, obs_arr
+    if inputs["Dataset"]["overwrite"] or not os.path.isfile(f"pz_inputs_{os.path.basename(h5catpath)}"):
+        ab_mags, ab_mags_errs, z_specs = readCatalogHDF5(h5catpath, filt_names=filters_names)
+
+        from .galaxy import vmap_mags_to_i_and_colors
+        i_mag_ab, ab_colors, ab_cols_errs = vmap_mags_to_i_and_colors(ab_mags, ab_mags_errs, inputs["i_band_num"])
+
+        clrh5file = f"pz_inputs_{os.path.basename(h5catpath)}"
+        _colrs_h5out = pzInputsToHDF5(clrh5file, ab_colors, ab_cols_errs, z_specs, i_mag_ab, filt_names=filters_names)
+    else:
+        i_mag_ab, ab_colors, ab_cols_errs, z_specs = readPZinputsHDF5(f"pz_inputs_{os.path.basename(h5catpath)}", filt_names=filters_names)
+
+    return z_grid, templ_dict, i_mag_ab, ab_colors, ab_cols_errs, z_specs
+
+
+def readCatalogHDF5(h5file, group="catalog", filt_names=None):
+    """readCatalogHDF5 Reads the magnitudes and spectroscopic redshift (if available) from a dictionary-like catalog provided as an `HDF5` file.
+    Preliminary step for the `process_fors2.photoZ` calculations.
+
+    :param h5file: Path to the HDF5 catalog file.
+    :type h5file: str or path-like
+    :param group: Identifier of the group to read within the `HDF5` file. This argument is passed to the `key` argument of `pandas.DataFrame.read_hdf`. Defaults to 'catalog'.
+    :type group: str, optional
+    :param filt_names: Names of filters to look for in the catalogs. Data recorded as `mag_[filter name]` and `mag_err_[filter name]` will be returned.
+    If None, defaults to LSST filters. Defaults to None.
+    :type filt_names: list of str, optional
+    :return: tuple containing AB magnitudes, corresponding errors and spectroscopic redshift as arrays.
+    :rtype: tuple of arrays
+    """
+    if filt_names is None:
+        filt_names = ["lsst_u", "lsst_g", "lsst_r", "lsst_i", "lsst_z", "lsst_y"]
+    df_cat = pd.read_hdf(os.path.abspath(h5file), key=group)
+    magnames = [f"mag_{filt}" for filt in filt_names]
+    magerrs = [f"mag_err_{filt}" for filt in filt_names]
+    obs_mags = jnp.array(df_cat[magnames])
+    obs_mags_errs = jnp.array(df_cat[magerrs])
+    try:
+        z_specs = jnp.array(df_cat["z_spec"])
+    except IndexError:
+        z_specs = jnp.full(obs_mags.shape[0], jnp.nan)
+    return obs_mags, obs_mags_errs, z_specs
+
+
+def catalog_ASCIItoHDF5(ascii_file, data_ismag, group="catalog", filt_names=None):
+    """catalog_ASCIItoHDF5 Reads a catalog provided as an ASCII file (as in LEPHARE) containing either fluxes or magnitudes and saves it in an `HDF5` file containing AB-magnitudes.
+
+    :param ascii_file: Path to the ASCII file containing catalog cata as an array that can be read with `numpy.loadtxt(ascii_file)`.
+    :type ascii_file: str or path-like
+    :param data_ismag: Whether the photometry in the file is given as AB-magnitudes or flux density (in erg/s/cm²/Hz). True for AB-magnitudes.
+    :type data_ismag: bool
+    :param group: Name of the group to write in the `HDF5` file. This argument is passed to the `key` argument of `pandas.DataFrame.to_hdf`. Defaults to 'catalog'.
+    :type group: str, optional
+    :param filt_names: Names of filters to use as column names in the catalog. Data will be recored as `mag_[filter name]` and `mag_err_[filter name]`.
+    If None, defaults to LSST filters. Defaults to None.
+    :type filt_names: list of str, optional
+    :return: Absolute path to the written file - if successful.
+    :rtype: str or path-like object
+    """
+    if filt_names is None:
+        filt_names = ["lsst_u", "lsst_g", "lsst_r", "lsst_i", "lsst_z", "lsst_y"]
+    magnames = [f"mag_{filt}" for filt in filt_names]
+    magerrs = [f"mag_err_{filt}" for filt in filt_names]
+    N_FILT = len(filt_names)
+    data_file_arr = np.loadtxt(os.path.abspath(ascii_file))
+    has_zspec = data_file_arr.shape[1] == 1 + 2 * N_FILT + 1
+    no_zspec = data_file_arr.shape[1] == 1 + 2 * N_FILT
+    assert has_zspec or no_zspec, "Number of column in data does not match one of 1 + 2*n_filts + 1 (id, photometry, z_spec) or 1 + 2*n_filts (id, photometry).\
+        \nReview data or filters list."
+
+    from .galaxy import vmap_load_magnitudes
+
+    all_mags, all_mags_err = vmap_load_magnitudes(data_file_arr[:, 1 : 2 * N_FILT + 1], data_ismag)
+
+    all_zs = data_file_arr[:, -1] if has_zspec else jnp.full(all_mags.shape[0], jnp.nan)
+
+    df_mags = pd.DataFrame(columns=magnames + magerrs + ["z_spec"], data=jnp.column_stack((all_mags, all_mags_err, all_zs)))
+
+    hdf_name = f"{os.path.splitext(os.path.basename(ascii_file))[0]}.h5"
+    outfilename = os.path.abspath(hdf_name)
+    df_mags.to_hdf(outfilename, key=group)
+    respath = outfilename if os.path.isfile(outfilename) else f"Unable to write data to {outfilename}"
+    return respath
+
+
+def pzInputsToHDF5(h5file, clrs_ind, clrs_ind_errs, z_specs, i_mags, filt_names=None):
+    """pzInputsToHDF5 Saves the photometry inputs as processed for the `process_fors2.photoZ` module, *i.e.* color indices, associated errors and spectro-z if available.
+    Filter names must match those used for the photo-z estimation. Allows not to reprocess the catalog everytime the code is used on a similar dataset.
+
+    :param h5file: Name for the HDF5 inputs file to be written.
+    :type h5file: str or path-like
+    :param clrs_ind: Array of color indices in magnitudes units
+    :type clrs_ind: array
+    :param clrs_ind_errs: Array of error on color indices in magnitudes units
+    :type clrs_ind_errs: array
+    :param z_specs: Array of spectroscopic redshifts (`jnp.nan` if unavailable in the catalog)
+    :type z_specs: array
+    :param i_mags: Array of magnitudes in i-band for nz prior computation.
+    :type i_mags: array
+    :param filt_names: Names of filters to use as column names in the catalog.
+    Color indices will be recorded as `[filter name i]-[filter name i+1]` and `[filter name i]-[filter name i+1]_err`.
+    If None, defaults to LSST filters. Defaults to None.
+    :type filt_names: list of str, optional
+    :return: Absolute path to the written file - if successful.
+    :rtype: str or path-like object
+    """
+    if filt_names is None:
+        filt_names = ["lsst_u", "lsst_g", "lsst_r", "lsst_i", "lsst_z", "lsst_y"]
+
+    color_names = [f"{n1}-{n2}" for (n1, n2) in zip(filt_names[:-1], filt_names[1:], strict=True)]
+
+    color_err_names = [f"{n1}-{n2}_err" for (n1, n2) in zip(filt_names[:-1], filt_names[1:], strict=True)]
+
+    df_clrs = pd.DataFrame(columns=color_names + color_err_names + ["i_mag", "z_spec"], data=jnp.column_stack((clrs_ind, clrs_ind_errs, i_mags, z_specs)))
+    outfilename = os.path.abspath(h5file)
+    df_clrs.to_hdf(outfilename, "pz_inputs")
+    respath = outfilename if os.path.isfile(outfilename) else f"Unable to write data to {outfilename}"
+    return respath
+
+
+def readPZinputsHDF5(h5file, filt_names=None):
+    """readPZinputsHDF5 Reads pre-existing photometry inputs for the `process_fors2.photoZ` module, *i.e.* color indices, associated errors and spectro-z if available.
+    Filter names must match those used for the photo-z estimation. Allows not to reprocess the catalog everytime the code is used on a similar dataset.
+
+    :param h5file: Path to the HDF5 inputs file.
+    :type h5file: str or path-like
+    :param filt_names: Names of filters to look for in the catalogs. Color indices `[filter name i]-[filter name i+1]` and `[filter name i]-[filter name i+1]_err` will be returned.
+    If None, defaults to LSST filters. Defaults to None.
+    :type filt_names: list of str, optional
+    :return: 4-tuple of JAX arrays containing data to perform photo-z estimation (`jnp.nan` if missing) : mags in i-band ; color indices ; associated errors and spectro-z.
+    :rtype: tuple(arrays)
+    """
+    if filt_names is None:
+        filt_names = ["lsst_u", "lsst_g", "lsst_r", "lsst_i", "lsst_z", "lsst_y"]
+
+    color_names = [f"{n1}-{n2}" for (n1, n2) in zip(filt_names[:-1], filt_names[1:], strict=True)]
+
+    color_err_names = [f"{n1}-{n2}_err" for (n1, n2) in zip(filt_names[:-1], filt_names[1:], strict=True)]
+
+    df_clrs = pd.read_hdf(os.path.abspath(h5file), key="pz_inputs")
+    colrs = jnp.array(df_clrs[color_names])
+    colrs_errs = jnp.array(df_clrs[color_err_names])
+    i_mags = jnp.array(df_clrs["i_mag"])
+    z_specs = jnp.array(df_clrs["z_spec"])
+    return i_mags, colrs, colrs_errs, z_specs


### PR DESCRIPTION
…n-ASCII (i.e. HDF5) input catalogues, as is expected within DESC.

## Problem & Solution Description (including issue #)
Tests were inconclusive regarding the speed of computations on GPUs at IDRIS. Changes were made in the related `process_fors2.photoZ` module and transposed to this repo after succesful runs. These changes include a different processing of input catalog that both enables reading non-ASCII files (i.e. HDF5 containing dicts or pandas-like tables) and dealing with them as multidimensional JAX arrays. The necessity of an Observation class has thus been removed and computations are MUCH faster.

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [x] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
